### PR TITLE
Feature/fix ObjectDisposedException when execute same query on different db contexts

### DIFF
--- a/src/Blueshift.EntityFrameworkCore.MongoDB/Storage/MongoDbDatabase.cs
+++ b/src/Blueshift.EntityFrameworkCore.MongoDB/Storage/MongoDbDatabase.cs
@@ -141,7 +141,10 @@ namespace Blueshift.EntityFrameworkCore.MongoDB.Storage
 
         /// <inheritdoc />
         public override Func<QueryContext, IAsyncEnumerable<TResult>> CompileAsyncQuery<TResult>(QueryModel queryModel)
-            => queryContext => CompileQuery<TResult>(queryModel)(queryContext).ToAsyncEnumerable();
+        {
+            var syncQueryExecutor = CompileQuery<TResult>(queryModel);
+            return queryContext => syncQueryExecutor(queryContext).ToAsyncEnumerable();
+        }
 
         private IUpdateEntry GetRootDocument(InternalEntityEntry entry)
         {


### PR DESCRIPTION
pull request to fix issue https://github.com/BlueshiftSoftware/EntityFrameworkCore/issues/41
changes:

- added test case for execute same async query twice on different dbContext instances
- removed compiling query from lambda expression in MongoDbDatabase.CompileQuery() method